### PR TITLE
Only update Packger Index when need install ccache

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -214,13 +214,15 @@ export default async function main(): Promise<void> {
       return;
     }
 
-    if (Core.getBooleanInput("update_packager_index"))
-      await updatePackgerIndex();
-    else
-      Core.info("Skip update packager index...");
-
-    if (Core.getBooleanInput("install_ccache"))
+    if (Core.getBooleanInput("install_ccache")) {
+      if (Core.getBooleanInput("update_packager_index")) {
+        await updatePackgerIndex();
+      }
+      else {
+        Core.info("Skip update packager index...");
+      }
       await installCcache();
+    }
     else
       Core.info("Skip install ccache...");
 


### PR DESCRIPTION
It's no need to update packger index if `install_ccache` is false.